### PR TITLE
鼠标锁优化

### DIFF
--- a/src/BedrockBoot.Base/Entry/ConfigEntry.cs
+++ b/src/BedrockBoot.Base/Entry/ConfigEntry.cs
@@ -29,6 +29,9 @@ namespace BedrockBoot.Base.Entry
         [JsonPropertyName("language")] public LanguageEnum Language { get; set; } = LanguageEnum.Chinese;
         [JsonPropertyName("gatherInfo")] public bool GatherInfo { get; set; } = true;
         [JsonPropertyName("isMouseLock")] public bool IsMouseLock { get; set; } = false;
+        [JsonPropertyName("isMouseLockForGdk")] public bool IsMouseLockForGdk { get; set; } = false;
+        [JsonPropertyName("isMouseLockReserve")] public bool IsMouseLockReserve { get; set; } = false;
+        [JsonPropertyName("mouseLockHotkey")] public string MouseLockHotkey { get; set; } = "Ctrl+Alt";
         [JsonPropertyName("isUseSystemWindow")] public bool IsUseSystemWindow { get; set; } = false;
         [JsonPropertyName("launchBehavior")] public LaunchBehaviorEnum LaunchBehavior { get; set; } = LaunchBehaviorEnum.Normal;
         [JsonPropertyName("mediaVolume")] public double MediaVolume { get; set; } = 20;

--- a/src/BedrockBoot.Windows/Models/Game/EasyLauncher.cs
+++ b/src/BedrockBoot.Windows/Models/Game/EasyLauncher.cs
@@ -24,6 +24,7 @@ public class EasyLauncher
     private Stopwatch _gameplayStopwatch; // 计时器
     private DateTime _gameStartTime; // 游戏开始时间
     private string _playerDataFilePath; // 玩家数据文件路径
+	private ProcessMouseLocker? _mouseLocker;
     
     private static int LaunchingCount { get; set; } = 0;
 
@@ -194,8 +195,8 @@ public class EasyLauncher
                     // 正常情况下 GDK 窗口是不需要锁的呜
                     if (VersionInfo.Info.BuildType == MinecraftBuildTypeVersion.UWP || BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockForGdk)
                     {
-                        var mouse = new ProcessMouseLocker(MinecraftProcess.Id);
-                        mouse.Start();
+                        _mouseLocker = new ProcessMouseLocker(MinecraftProcess.Id);
+                        _mouseLocker.Start();
                     }
                 }
 
@@ -242,6 +243,14 @@ public class EasyLauncher
             }
             
             Console.WriteLine(@"游戏进程已退出（异步等待）");
+			if (BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLock)
+			{
+    			if (VersionInfo.Info.BuildType == MinecraftBuildTypeVersion.UWP || BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockForGdk)
+			    {
+			        _mouseLocker?.Stop();
+			        _mouseLocker = null;
+			    }
+			}
             LaunchCompleted?.Invoke();
         }
         catch (Exception ex)

--- a/src/BedrockBoot.Windows/Models/Game/EasyLauncher.cs
+++ b/src/BedrockBoot.Windows/Models/Game/EasyLauncher.cs
@@ -191,8 +191,12 @@ public class EasyLauncher
                 
                 if (BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLock)
                 {
-                    var mouse = new ProcessMouseLocker(MinecraftProcess.Id);
-                    mouse.Start();
+                    // 正常情况下 GDK 窗口是不需要锁的呜
+                    if (VersionInfo.Info.BuildType == MinecraftBuildTypeVersion.UWP || BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockForGdk)
+                    {
+                        var mouse = new ProcessMouseLocker(MinecraftProcess.Id);
+                        mouse.Start();
+                    }
                 }
 
                 if (VersionInfo.Config.IsModes) _core.LoadAll(MinecraftProcess.Id);

--- a/src/BedrockBoot.Windows/Models/Helper/HotkeyHelper.cs
+++ b/src/BedrockBoot.Windows/Models/Helper/HotkeyHelper.cs
@@ -1,0 +1,516 @@
+﻿using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace BedrockBoot.Models.Helper
+{
+
+    public sealed class HotKey
+    {
+        public int? VirtualKey { get; set; } // 允许为空
+
+        public HotKeyModifier Modifiers { get; set; }
+
+        public override string ToString()
+        {
+            var parts = new List<string>();
+
+            if (Modifiers.HasFlag(HotKeyModifier.Ctrl))
+                parts.Add("Ctrl");
+
+            if (Modifiers.HasFlag(HotKeyModifier.Alt))
+                parts.Add("Alt");
+
+            if (Modifiers.HasFlag(HotKeyModifier.Shift))
+                parts.Add("Shift");
+
+            if (Modifiers.HasFlag(HotKeyModifier.Win))
+                parts.Add("Win");
+
+            // 没有 Key 时只输出修饰键
+            if (VirtualKey.HasValue)
+                parts.Add(GetKeyName(VirtualKey.Value));
+
+            return string.Join("+", parts);
+        }
+        public static HotKey Parse(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                throw new ArgumentException("Hotkey string is empty.");
+
+            var parts = text.Split('+', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            HotKeyModifier modifiers = HotKeyModifier.None;
+            int? key = null;
+
+            foreach (var raw in parts)
+            {
+                var part = raw.Trim();
+
+                // modifiers
+                switch (part.ToLowerInvariant())
+                {
+                    case "ctrl":
+                        modifiers |= HotKeyModifier.Ctrl;
+                        continue;
+                    case "alt":
+                        modifiers |= HotKeyModifier.Alt;
+                        continue;
+                    case "shift":
+                        modifiers |= HotKeyModifier.Shift;
+                        continue;
+                    case "win":
+                    case "meta":
+                        modifiers |= HotKeyModifier.Win;
+                        continue;
+                }
+
+                // key（最后一个非 modifier）
+                key = ParseKey(part);
+            }
+
+            return new HotKey
+            {
+                Modifiers = modifiers,
+                VirtualKey = key
+            };
+        }
+        private static int ParseKey(string text)
+        {
+            if (SpecialKeys.TryGetValue(text, out var vk))
+                return vk;
+
+            if (OemKeys.TryGetValue(text, out vk))
+                return vk;
+
+            if (text.StartsWith("F", StringComparison.OrdinalIgnoreCase) && int.TryParse(text[1..], out int f) && f >= 1 && f <= 24)
+            {
+                return 0x70 + (f - 1);
+            }
+            if (text.StartsWith("NumPad", StringComparison.OrdinalIgnoreCase) && int.TryParse(text[6..], out int n) && n >= 0 && n <= 9)
+            {
+                return 0x60 + n;
+            }
+            if (text.Length == 1)
+            {
+                char c = char.ToUpperInvariant(text[0]);
+
+                if (c >= 'A' && c <= 'Z')
+                    return c;
+
+                if (c >= '0' && c <= '9')
+                    return c;
+            }
+            if (text.StartsWith("VK_", StringComparison.OrdinalIgnoreCase))
+            {
+                return Convert.ToInt32(text[3..], 16);
+            }
+
+            throw new FormatException($"Unknown key: {text}");
+        }
+
+        private static readonly Dictionary<string, int> OemKeys = new()
+        {
+            [";"] = 0xBA,
+            ["="] = 0xBB,
+            [","] = 0xBC,
+            ["-"] = 0xBD,
+            ["."] = 0xBE,
+            ["/"] = 0xBF,
+            ["`"] = 0xC0,
+            ["["] = 0xDB,
+            ["\\"] = 0xDC,
+            ["]"] = 0xDD,
+            ["'"] = 0xDE,
+        };
+        private static readonly Dictionary<string, int> SpecialKeys = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Left"] = 0x25,
+            ["Up"] = 0x26,
+            ["Right"] = 0x27,
+            ["Down"] = 0x28,
+
+            ["PageUp"] = 0x21,
+            ["PageDown"] = 0x22,
+
+            ["Home"] = 0x24,
+            ["End"] = 0x23,
+
+            ["Insert"] = 0x2D,
+            ["Delete"] = 0x2E,
+
+            ["Backspace"] = 0x08,
+            ["Tab"] = 0x09,
+            ["Enter"] = 0x0D,
+            ["Escape"] = 0x1B,
+            ["Space"] = 0x20,
+
+            ["CapsLock"] = 0x14,
+            ["NumLock"] = 0x90,
+            ["ScrollLock"] = 0x91,
+
+            ["Pause"] = 0x13,
+            ["PrintScreen"] = 0x2C,
+
+            ["Apps"] = 0x5D,
+
+            ["Multiply"] = 0x6A,
+            ["Add"] = 0x6B,
+            ["Separator"] = 0x6C,
+            ["Subtract"] = 0x6D,
+            ["Decimal"] = 0x6E,
+            ["Divide"] = 0x6F,
+        };
+        public static bool TryParse(string text, out HotKey hotkey)
+        {
+            try
+            {
+                hotkey = Parse(text);
+                return true;
+            }
+            catch
+            {
+                hotkey = null!;
+                return false;
+            }
+        }
+        public bool IsPressed()
+        {
+            bool Check(int vk)
+                => (GetAsyncKeyState(vk) & 0x8000) != 0;
+
+            if (Modifiers.HasFlag(HotKeyModifier.Ctrl) && !Check(0x11))
+                return false;
+
+            if (Modifiers.HasFlag(HotKeyModifier.Alt) && !Check(0x12))
+                return false;
+
+            if (Modifiers.HasFlag(HotKeyModifier.Shift) && !Check(0x10))
+                return false;
+
+            if (VirtualKey.HasValue)
+                return Check(VirtualKey.Value);
+
+            return true;
+        }
+
+        private static string GetKeyName(int vk)
+        {
+            return vk switch
+            {
+                >= 0x70 and <= 0x87 => $"F{vk - 0x6F}",
+
+                0x25 => "Left",
+                0x26 => "Up",
+                0x27 => "Right",
+                0x28 => "Down",
+
+                0x21 => "PageUp",
+                0x22 => "PageDown",
+                0x23 => "End",
+                0x24 => "Home",
+
+                0x2D => "Insert",
+                0x2E => "Delete",
+
+                0x08 => "Backspace",
+                0x09 => "Tab",
+                0x0D => "Enter",
+                0x1B => "Escape",
+                0x20 => "Space",
+
+                >= 0x30 and <= 0x39 => ((char)vk).ToString(), // 0-9
+                >= 0x41 and <= 0x5A => ((char)vk).ToString(), // A-Z
+
+                0x60 => "NumPad0",
+                0x61 => "NumPad1",
+                0x62 => "NumPad2",
+                0x63 => "NumPad3",
+                0x64 => "NumPad4",
+                0x65 => "NumPad5",
+                0x66 => "NumPad6",
+                0x67 => "NumPad7",
+                0x68 => "NumPad8",
+                0x69 => "NumPad9",
+
+                0x6A => "Multiply",
+                0x6B => "Add",
+                0x6C => "Separator",
+                0x6D => "Subtract",
+                0x6E => "Decimal",
+                0x6F => "Divide",
+
+                0x90 => "NumLock",
+                0x91 => "ScrollLock",
+                0x14 => "CapsLock",
+
+                0x13 => "Pause",
+                0x2C => "PrintScreen",
+
+                0x5D => "Apps",
+
+                // OEM keys（键盘符号区）
+                0xBA => ";",
+                0xBB => "=",
+                0xBC => ",",
+                0xBD => "-",
+                0xBE => ".",
+                0xBF => "/",
+                0xC0 => "`",
+                0xDB => "[",
+                0xDC => "\\",
+                0xDD => "]",
+                0xDE => "'",
+
+                _ => $"VK_{vk:X2}"
+            };
+        }
+
+        [DllImport("user32.dll")]
+        private static extern short GetAsyncKeyState(int vKey);
+
+        private const int VK_CONTROL = 0x11;
+        private const int VK_MENU = 0x12;
+        private const int VK_SHIFT = 0x10;
+        private const int VK_LWIN = 0x5B;
+        private const int VK_RWIN = 0x5C;
+    }
+
+    [Flags]
+    public enum HotKeyModifier
+    {
+        None = 0,
+        Ctrl = 1,
+        Alt = 2,
+        Shift = 4,
+        Win = 8
+    }
+
+    public static class HotKeyHelper
+    {
+        public sealed class HotKeyCaptureSession : IDisposable
+        {
+            private readonly TopLevel _topLevel;
+            private readonly TaskCompletionSource<HotKey> _tcs;
+
+            private bool _finished;
+
+            private HotKeyModifier _modifiers;
+            private int? _key;
+
+            public Task<HotKey> Task => _tcs.Task;
+
+            public HotKeyCaptureSession(TopLevel topLevel)
+            {
+                _topLevel = topLevel;
+                _tcs = new TaskCompletionSource<HotKey>();
+
+                _topLevel.AddHandler(InputElement.KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
+                _topLevel.AddHandler(InputElement.KeyUpEvent, OnKeyUp, RoutingStrategies.Tunnel);
+                _topLevel.LostFocus += OnLostFocus;
+            }
+
+            private void OnLostFocus(object? sender, EventArgs e)
+                => Cancel();
+
+            private void OnKeyDown(object? sender, KeyEventArgs e)
+            {
+                if (e.Key == Key.Escape)
+                {
+                    Cancel();
+                    return;
+                }
+
+                _modifiers = HotKeyHelper.ConvertModifiers(e.KeyModifiers);
+
+                // 记录最后一个“非修饰键”
+                if (!IsModifierKey(e.Key))
+                {
+                    _key = HotKeyHelper.ToVirtualKey(e.Key);
+                }
+
+                e.Handled = true;
+            }
+
+            private void OnKeyUp(object? sender, KeyEventArgs e)
+            {
+                if (_finished)
+                    return;
+
+                
+                // 只要有修饰键变化发生释放 → 可以提交
+
+                bool hasModifiers = _modifiers != HotKeyModifier.None;
+
+                if (!hasModifiers && !_key.HasValue)
+                    return;
+
+                Finish(new HotKey
+                {
+                    VirtualKey = _key,   // 可以为 null（纯修饰键组合）
+                    Modifiers = _modifiers
+                });
+            }
+
+            private void Finish(HotKey hotkey)
+            {
+                if (_finished) return;
+
+                _finished = true;
+
+                _topLevel.RemoveHandler(InputElement.KeyDownEvent, OnKeyDown);
+                _topLevel.RemoveHandler(InputElement.KeyUpEvent, OnKeyUp);
+                _topLevel.LostFocus -= OnLostFocus;
+
+                _tcs.TrySetResult(hotkey);
+            }
+
+            private void Cancel()
+            {
+                if (_finished) return;
+
+                _finished = true;
+
+                _topLevel.RemoveHandler(InputElement.KeyDownEvent, OnKeyDown);
+                _topLevel.RemoveHandler(InputElement.KeyUpEvent, OnKeyUp);
+                _topLevel.LostFocus -= OnLostFocus;
+
+                _tcs.TrySetResult(null!);
+            }
+            private static bool IsModifierKey(Key key)
+            {
+                return key is
+                    Key.LeftCtrl or Key.RightCtrl or
+                    Key.LeftAlt or Key.RightAlt or
+                    Key.LeftShift or Key.RightShift or
+                    Key.LWin or Key.RWin;
+            }
+            public void Dispose() => Cancel();
+        }
+
+        public static HotKeyCaptureSession Begin(InputElement element)
+        {
+            var topLevel = TopLevel.GetTopLevel(element)
+                  ?? throw new InvalidOperationException("No TopLevel found");
+
+            topLevel.Focus();
+
+            return new HotKeyCaptureSession(topLevel);
+        }
+
+        internal static HotKeyModifier ConvertModifiers(KeyModifiers modifiers)
+        {
+            HotKeyModifier result = HotKeyModifier.None;
+
+            if (modifiers.HasFlag(KeyModifiers.Control))
+                result |= HotKeyModifier.Ctrl;
+
+            if (modifiers.HasFlag(KeyModifiers.Alt))
+                result |= HotKeyModifier.Alt;
+
+            if (modifiers.HasFlag(KeyModifiers.Shift))
+                result |= HotKeyModifier.Shift;
+
+            if (modifiers.HasFlag(KeyModifiers.Meta))
+                result |= HotKeyModifier.Win;
+
+            return result;
+        }
+
+        internal static int ToVirtualKey(Key key)
+        {
+            return key switch
+            {
+                Key.F1 => 0x70,
+                Key.F2 => 0x71,
+                Key.F3 => 0x72,
+                Key.F4 => 0x73,
+                Key.F5 => 0x74,
+                Key.F6 => 0x75,
+                Key.F7 => 0x76,
+                Key.F8 => 0x77,
+                Key.F9 => 0x78,
+                Key.F10 => 0x79,
+                Key.F11 => 0x7A,
+                Key.F12 => 0x7B,
+                Key.F13 => 0x7C,
+                Key.F14 => 0x7D,
+                Key.F15 => 0x7E,
+                Key.F16 => 0x7F,
+                Key.F17 => 0x80,
+                Key.F18 => 0x81,
+                Key.F19 => 0x82,
+                Key.F20 => 0x83,
+                Key.F21 => 0x84,
+                Key.F22 => 0x85,
+                Key.F23 => 0x86,
+                Key.F24 => 0x87,
+
+                Key.Left => 0x25,
+                Key.Up => 0x26,
+                Key.Right => 0x27,
+                Key.Down => 0x28,
+
+                Key.PageUp => 0x21,
+                Key.PageDown => 0x22,
+                Key.Home => 0x24,
+                Key.End => 0x23,
+
+                Key.Insert => 0x2D,
+                Key.Delete => 0x2E,
+
+                Key.Back => 0x08,
+                Key.Tab => 0x09,
+                Key.Enter => 0x0D,
+                Key.Escape => 0x1B,
+                Key.Space => 0x20,
+
+                Key.CapsLock => 0x14,
+
+                >= Key.A and <= Key.Z => 0x41 + (key - Key.A),
+
+                >= Key.D0 and <= Key.D9 => 0x30 + (key - Key.D0),
+
+                Key.NumPad0 => 0x60,
+                Key.NumPad1 => 0x61,
+                Key.NumPad2 => 0x62,
+                Key.NumPad3 => 0x63,
+                Key.NumPad4 => 0x64,
+                Key.NumPad5 => 0x65,
+                Key.NumPad6 => 0x66,
+                Key.NumPad7 => 0x67,
+                Key.NumPad8 => 0x68,
+                Key.NumPad9 => 0x69,
+
+                Key.Multiply => 0x6A,
+                Key.Add => 0x6B,
+                Key.Separator => 0x6C,
+                Key.Subtract => 0x6D,
+                Key.Decimal => 0x6E,
+                Key.Divide => 0x6F,
+
+                Key.OemSemicolon => 0xBA,
+                Key.OemPlus => 0xBB,
+                Key.OemComma => 0xBC,
+                Key.OemMinus => 0xBD,
+                Key.OemPeriod => 0xBE,
+                Key.OemQuestion => 0xBF,
+                Key.OemTilde => 0xC0,
+                Key.OemOpenBrackets => 0xDB,
+                Key.OemPipe => 0xDC,
+                Key.OemCloseBrackets => 0xDD,
+                Key.OemQuotes => 0xDE,
+
+                Key.PrintScreen => 0x2C,
+                Key.Pause => 0x13,
+                Key.Apps => 0x5D,
+
+                _ => (int)key
+            };
+        }
+    }
+}

--- a/src/BedrockBoot.Windows/Models/Helper/ProcessMouseLocker.cs
+++ b/src/BedrockBoot.Windows/Models/Helper/ProcessMouseLocker.cs
@@ -299,6 +299,7 @@ public class ProcessMouseLocker
 
         }
         ClipCursor(IntPtr.Zero);
+		_lastClipRect = null;
         _isMouseCurrentlyLocked = false;
 
     }

--- a/src/BedrockBoot.Windows/Models/Helper/ProcessMouseLocker.cs
+++ b/src/BedrockBoot.Windows/Models/Helper/ProcessMouseLocker.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using BedrockBoot.Core.Global;
+using BedrockBoot.Models.Helper.Notice;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-using System.Diagnostics;
-using BedrockBoot.Models.Helper.Notice;
+
+
 
 namespace BedrockBoot.Models.Helper;
 
@@ -13,12 +14,30 @@ public class ProcessMouseLocker
     [DllImport("user32.dll")]
     private static extern IntPtr GetForegroundWindow();
 
+
+    /* 
+     *    ClipCursor(IntPtr.Zero) 似乎不需要重复执行
+     *    这样别的应用万一自带裁剪区域操作，就被我们给干掉了
+     *    闹
+     */
     [DllImport("user32.dll")]
     private static extern bool ClipCursor(ref Rect lpRect);
 
     [DllImport("user32.dll")]
     private static extern bool ClipCursor(IntPtr lpRect);
 
+    /* 
+     *   ShowCursor 搞不太清楚，
+     *   问了一下 GPT，解释是这个并不是布尔开关，
+     *   Windows 内部维护：DisplayCounter
+     *   例如：初始 = 0
+     *   调用：ShowCursor(false);
+     *   变成：-1，此时为隐藏
+     *   再调用一次：ShowCursor(false);
+     *   变成：-2，此时还是隐藏
+     *   此时如果调用ShowCursor(true);
+     *   变成：-1，此时仍然隐藏
+    */
     [DllImport("user32.dll")]
     private static extern bool ShowCursor(bool bShow);
 
@@ -42,25 +61,27 @@ public class ProcessMouseLocker
 
     [DllImport("dwmapi.dll")]
     private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out Rect pvAttribute, int cbAttribute);
-    
-    [DllImport("user32.dll")]
-    private static extern short GetAsyncKeyState(int vKey);
+
+ 
 
     private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
 
     // --- 常量定义 ---
     private const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
-    private const int VK_CONTROL = 0x11;
-    private const int VK_MENU = 0x12; // Alt 键
+
 
     // --- 成员变量 ---
     private readonly int _targetPid;
     private readonly DateTime _targetStartTime;
     private IntPtr _targetHwnd = IntPtr.Zero;
     private bool _isRunning = false;
-    private bool _isManuallyUnlocked = false; 
+    private bool _isManuallyUnlocked = false;
+    private bool _isMouseCurrentlyLocked;
     private bool _wasWindowFound = false; // 用于控制通知只发一次
-    private Thread _monitorThread;
+    private Thread _monitorHotkeyThread;
+    private Thread _monitorForegroundThread;
+    private HotKey _hotKey = HotKey.Parse(GlobalModel.Config.Data.MouseLockHotkey);
+    private Rect? _lastClipRect;
 
     public int BorderMargin { get; set; } = 20;
 
@@ -72,9 +93,9 @@ public class ProcessMouseLocker
             using var p = Process.GetProcessById(processId);
             _targetStartTime = p.StartTime;
         }
-        catch 
-        { 
-            _targetStartTime = DateTime.Now; 
+        catch
+        {
+            _targetStartTime = DateTime.Now;
         }
     }
 
@@ -88,12 +109,21 @@ public class ProcessMouseLocker
         _wasWindowFound = false;
         _targetHwnd = IntPtr.Zero;
 
-        _monitorThread = new Thread(MonitorLoop) 
-        { 
-            IsBackground = true, 
-            Name = "MouseLockerMonitor" 
+
+        // 监视热键和监视焦点窗口分为两个，热键需要高频率监视，但是焦点窗口不需要
+        _monitorHotkeyThread = new Thread(MonitorHotkeyLoop)
+        {
+            IsBackground = true,
+            Name = "MouseLockerHotkeyMonitor"
         };
-        _monitorThread.Start();
+        _monitorHotkeyThread.Start();
+
+        _monitorForegroundThread = new Thread(MonitorForegroundLoop)
+        {
+            IsBackground = true,
+            Name = "MouseLockerForegroundMonitor"
+        };
+        _monitorForegroundThread.Start();
     }
 
     /// <summary>
@@ -105,11 +135,20 @@ public class ProcessMouseLocker
         UnlockMouseInternal();
     }
 
-    private void MonitorLoop()
+    private void MonitorHotkeyLoop()
     {
         while (_isRunning)
         {
             // 1. 热键检测 (Ctrl + Alt)
+
+            // 原来的写法有大问题啊。原来检测到了热键暂时释放了之后，由于检测到了焦点依然在游戏上，所以又给锁上了，并且还标记 _isManuallyUnlocked = false，那这样这个标记还有什么意义，去掉了也没有区别
+            // 导致热键必须得一直按住才能临时解锁
+            // 而且，热键的 CD 是 300ms，锁上的 CD 是 15ms，就算保持按住热键，移动鼠标的时候还是卡顿的
+
+            // 因为用户解锁鼠标，往往目的是把焦点改变为其他应用，如果在此之后焦点又回来了，就可以自动重新锁上
+            // 所以，检测到热键之后，解锁，并且标记 _isManuallyUnlocked 为 true 之后
+            // 正确的做法应该是在检测到焦点切换到其他窗口的时候才标记 _isManuallyUnlocked 为 false
+            // 当然，如果在解锁期间再按一次热键也可以锁回去（（
             if (IsHotkeyPressed())
             {
                 if (!_isManuallyUnlocked)
@@ -118,24 +157,42 @@ public class ProcessMouseLocker
                     UnlockMouseInternal();
                     Thread.Sleep(300); // 防止热键重复触发
                 }
+                // 如果在临时释放期间再按一次热键，那就再锁回去吧 xwx
+                else
+                {
+                    _isManuallyUnlocked = false;
+                    LockMouseInternal();
+                    Thread.Sleep(300);
+                }
             }
+            Thread.Sleep(15); // 约 60Hz 频率检查
+
+        }
+    }
+    private void MonitorForegroundLoop()
+    {
+        while (_isRunning)
+        {
+            
 
             // 2. 窗口有效性检查与持续搜索
             bool isCurrentWindowValid = _targetHwnd != IntPtr.Zero && IsWindowVisible(_targetHwnd);
-            
+
             if (!isCurrentWindowValid)
             {
                 _targetHwnd = SearchForTargetWindow();
-                
+
                 if (_targetHwnd != IntPtr.Zero)
                 {
                     // 刚找到窗口时发送通知
                     if (!_wasWindowFound)
                     {
-                        try {
+                        try
+                        {
                             // 调用你的通知组件
-                            NoticeHelper.SentNotice("游戏已捕获", "鼠标锁定已就绪 (Ctrl+Alt 解锁 或 Win 解锁)");
-                        } catch { }
+                            NoticeHelper.SentNotice("游戏已捕获", "鼠标锁定已就绪 (按 "+ _hotKey.ToString() + " 或 Win 解锁)");
+                        }
+                        catch { }
                         _wasWindowFound = true;
                     }
                 }
@@ -144,19 +201,27 @@ public class ProcessMouseLocker
                     // 没找到窗口，重置状态并继续等待
                     _wasWindowFound = false;
                     UnlockMouseInternal();
-                    Thread.Sleep(500); 
+                    Thread.Sleep(500);
                     continue;
                 }
             }
 
             // 3. 焦点判断与锁定逻辑
             IntPtr foregroundHwnd = GetForegroundWindow();
+            DateTime now = DateTime.Now;
+
+            System.Diagnostics.Debug.WriteLine(now+""+foregroundHwnd);
+
             bool isOurWindowFocused = IsWindowBelongsToTarget(foregroundHwnd);
 
             if (isOurWindowFocused)
             {
+
+                System.Diagnostics.Debug.WriteLine(now+"OurWindowFocused");
                 // 如果回到了游戏窗口，自动恢复锁定状态
-                if (_isManuallyUnlocked)
+
+                // 前面解释了，不应该在这个时候将 _isManuallyUnlocked 赋值为 false
+                if (_isManuallyUnlocked && BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockReserve)
                 {
                     _isManuallyUnlocked = false;
                 }
@@ -167,33 +232,75 @@ public class ProcessMouseLocker
             {
                 // 窗口失去焦点（Alt+Tab等），自动释放鼠标
                 UnlockMouseInternal();
-            }
 
-            Thread.Sleep(15); // 约 60Hz 频率检查
+                // 正确的将 _isManuallyUnlocked 赋值为 false 的时机应该在这里
+                if (_isManuallyUnlocked && !BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockReserve)
+                {
+                    _isManuallyUnlocked = false;
+                }
+            }
+            if (BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockReserve)
+            {
+                Thread.Sleep(15); // 约 60Hz 频率检查
+            }
+            else
+            {
+                // 其实不用那么高频率检查的，占 CPU 是一回事（划掉）
+                // 因为 ClipCursor() 之后，除非被你释放了，要不然是一直保持着的（
+                // 换句话说，ClipCursor() 的原理是限制光标的移动范围。
+                // 范围已被限制的前提下只需低频率检查是否失去焦点来执行一次释放即可。
+                // 我们默认没有其他应用和我们抢夺。
+                Thread.Sleep(500);
+
+
+            }
         }
     }
 
     private bool IsHotkeyPressed()
     {
-        return (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0 && 
-               (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+        return _hotKey.IsPressed();
     }
 
     private void LockMouseInternal()
     {
         if (_isManuallyUnlocked) return;
 
-        ShowCursor(false);
+
+        // ShowCursor() 搞不太清楚其实，虽然能跑就别动，但是我还是留了个开关 ，万一出问题了呢
+        if (BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockReserve)
+        {
+            ShowCursor(false);
+
+        }
         if (TryGetWindowBounds(_targetHwnd, out Rect rect))
         {
+            // 如果裁切不需要改变就不重新进行裁切
+            if (_lastClipRect.HasValue && _lastClipRect.Value.Equals(rect) && !BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockReserve) return;
+
             ClipCursor(ref rect);
+            _lastClipRect = rect;
+
         }
+        _isMouseCurrentlyLocked = true;
+
     }
 
     private void UnlockMouseInternal()
     {
-        ShowCursor(true);
+        // 如果当前是释放的情况下，就不需要重复多次释放了
+        // 否则别的鼠标锁定本来是正常的游戏，例如 GDK 版的 Minecraft，或者原神、PUBG 等，就被我们的反复释放操作给干掉了
+        if (!_isMouseCurrentlyLocked && !BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockReserve) return;
+
+
+        if (BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockReserve)
+        {
+            ShowCursor(true);
+
+        }
         ClipCursor(IntPtr.Zero);
+        _isMouseCurrentlyLocked = false;
+
     }
 
     private bool IsWindowBelongsToTarget(IntPtr hwnd)
@@ -221,7 +328,7 @@ public class ProcessMouseLocker
             string className = sbClass.ToString();
 
             // 排除控制台窗口，防止误锁
-            if (className.Contains("ConsoleWindowClass") || className.Contains("Ghost")) 
+            if (className.Contains("ConsoleWindowClass") || className.Contains("Ghost"))
                 return true;
 
             GetWindowThreadProcessId(hWnd, out uint pid);
@@ -229,8 +336,13 @@ public class ProcessMouseLocker
             // 路径 1: GDK/普通窗口直接匹配 PID
             if (pid == _targetPid)
             {
-                foundHandle = hWnd;
-                return false;
+                // 正常情况下 GDK 窗口是不需要锁的呜
+                if (BedrockBoot.Core.Global.GlobalModel.Config.Data.IsMouseLockForGdk)
+                {
+                    foundHandle = hWnd;
+                    return false;
+                }
+                return true;
             }
 
             // 路径 2: UWP 窗口 (ApplicationFrameHost.exe)
@@ -292,11 +404,11 @@ public class ProcessMouseLocker
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct Rect 
-    { 
-        public int Left; 
-        public int Top; 
-        public int Right; 
-        public int Bottom; 
+    public struct Rect
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
     }
 }

--- a/src/BedrockBoot.Windows/Models/Helper/ProcessMouseLocker.cs
+++ b/src/BedrockBoot.Windows/Models/Helper/ProcessMouseLocker.cs
@@ -208,16 +208,10 @@ public class ProcessMouseLocker
 
             // 3. 焦点判断与锁定逻辑
             IntPtr foregroundHwnd = GetForegroundWindow();
-            DateTime now = DateTime.Now;
-
-            System.Diagnostics.Debug.WriteLine(now+""+foregroundHwnd);
-
             bool isOurWindowFocused = IsWindowBelongsToTarget(foregroundHwnd);
 
             if (isOurWindowFocused)
             {
-
-                System.Diagnostics.Debug.WriteLine(now+"OurWindowFocused");
                 // 如果回到了游戏窗口，自动恢复锁定状态
 
                 // 前面解释了，不应该在这个时候将 _isManuallyUnlocked 赋值为 false

--- a/src/BedrockBoot/I18n/zh_CN.axaml
+++ b/src/BedrockBoot/I18n/zh_CN.axaml
@@ -589,6 +589,17 @@
     <x:String x:Key="Settings.Game.Isolation.HookSymbolicLink">混合模式（Hook + Symbolic Link）</x:String>
     <x:String x:Key="Settings.Game.MouseLock.Title">鼠标锁</x:String>
     <x:String x:Key="Settings.Game.MouseLock.Desc">防止鼠标越过游戏窗口边界，避免误触其他内容</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Main.Title">总开关</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Main.Desc">只有总开关开启时，功能才会生效</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Advance">高级</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.ForGdk.Title">对 GDK 版本生效</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.ForGdk.Desc">正常情况下，只有 UWP 版本才需要鼠标锁</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Reserve.Title">旧版逻辑</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Reserve.Desc">除非新版鼠标锁逻辑未能按照预期工作，否则你不应该打开这个开关</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Reserve.Warn">旧版本鼠标锁逻辑更为粗暴，除了不必要的 CPU 浪费之外，还会导致其他应用或游戏自带的鼠标锁定逻辑出现异常，&#10;且会导致解除锁定的热键工作异常。&#10;除非新版鼠标锁逻辑未能按照预期工作，否则你的确不应该打开这个开关！&#10;&#10;确认仍要打开吗？</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Hotkey.Title">热键绑定</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Hotkey.Desc">绑定临时解除鼠标锁定的热键</x:String>
+	<x:String x:Key="Settings.Game.MouseLock.Hotkey.Capturing">捕获中，按 Esc 取消</x:String>
     <x:String x:Key="Settings.Game.Group.Advanced">高级</x:String>
     <x:String x:Key="Settings.Game.Proton.Desc">管理和设置 Proton 运行器</x:String>
     <x:String x:Key="Settings.Game.Proton.Install.Title">安装新 Proton</x:String>

--- a/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGame.axaml
+++ b/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGame.axaml
@@ -41,12 +41,12 @@
             </onePointControls:SettingCard>
 
             <onePointControls:SettingCard Margin="5, 0"
-                                          Name="MouseLockCard"
+                                          Name="MouseLockBtn"
+                                          Click="MouseLockBtn_OnClick"
+                                          IsClickable="True"
                                           Header="{DynamicResource Settings.Game.MouseLock.Title}"
                                           Description="{DynamicResource Settings.Game.MouseLock.Desc}"
                                           Glyph="&#xE72E;">
-                <ToggleSwitch Name="MouseLockSwitch"
-                              IsCheckedChanged="MouseLockSwitch_OnIsCheckedChanged" />
             </onePointControls:SettingCard>
 
             <onePointControls:SettingCard Margin="5, 0"

--- a/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGame.axaml.cs
+++ b/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGame.axaml.cs
@@ -28,7 +28,6 @@ public partial class SettingGame : ISettingPage
         // 从配置中还原隔离模式索引
         IsolationTypeBox.SelectedIndex = (int)GlobalModel.Config.Data.IsolationModel;
         IsolationPriority.SelectedIndex = (int)GlobalModel.Config.Data.IsolationPriority;
-        MouseLockSwitch.IsChecked = GlobalModel.Config.Data.IsMouseLock;
 
 #if RELEASE && LINUX
         SeniorPanel.IsVisible = Models.Global.GlobalModel.FunctionOption.IsEnableGameProtonManager;
@@ -36,7 +35,7 @@ public partial class SettingGame : ISettingPage
 
 #if LINUX
         IsolationCard.IsVisible = false;
-        MouseLockCard.IsVisible = false;
+        MouseLockBtn.IsVisible = false;
 #endif
 
 #if LINUX && DEBUG
@@ -62,13 +61,9 @@ public partial class SettingGame : ISettingPage
         MainSettingPage.NavigateTo(new GameFolders());
     }
 
-    private void MouseLockSwitch_OnIsCheckedChanged(object? sender, RoutedEventArgs e)
+     private void MouseLockBtn_OnClick(object? sender, RoutedEventArgs e)
     {
-        if (IsEdit)
-        {
-            GlobalModel.Config.Data.IsMouseLock = (bool)MouseLockSwitch.IsChecked!;
-            GlobalModel.Config.Save();
-        }
+        MainSettingPage.NavigateTo(new MouseLock());
     }
 
     private void ProtonBtn_OnClick(object? sender, RoutedEventArgs e)

--- a/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGamePages/MouseLock.axaml
+++ b/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGamePages/MouseLock.axaml
@@ -1,0 +1,61 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:onePointControls="clr-namespace:OnePointUI.Avalonia.Styling.Controls.OnePointControls;assembly=OnePointUI.Avalonia"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="BedrockBoot.Views.Pages.SettingSubPage.SettingGamePages.MouseLock">
+	<ScrollViewer>
+		<StackPanel Margin="15"
+                    Spacing="8">
+			<onePointControls:SettingCard Margin="5, 0"
+                                          Name="MouseLockMainCard"
+                                          Header="{DynamicResource Settings.Game.MouseLock.Main.Title}"
+                                          Description="{DynamicResource Settings.Game.MouseLock.Main.Desc}"
+                                          Glyph="&#xF19E;">
+				<ToggleSwitch Name="MouseLockMainSwitch"
+                              IsCheckedChanged="MouseLockMainSwitch_OnIsCheckedChanged" />
+			</onePointControls:SettingCard>
+
+			<TextBlock Margin="5,0"
+                       FontWeight="Bold"
+                       FontSize="14"
+                       Text="{DynamicResource Settings.Game.MouseLock.Advance}" />
+
+			<onePointControls:SettingCard Margin="5, 0"
+                                          Name="MouseLockForGdkCard"
+                                          Header="{DynamicResource Settings.Game.MouseLock.ForGdk.Title}"
+                                          Description="{DynamicResource Settings.Game.MouseLock.ForGdk.Desc}"
+                                          Glyph="&#xE737;">
+				<ToggleSwitch Name="MouseLockForGdkSwitch"
+                              IsCheckedChanged="MouseLockForGdkSwitch_OnIsCheckedChanged" />
+			</onePointControls:SettingCard>
+
+			<onePointControls:SettingCard Margin="5, 0"
+                                          Name="MouseLockReserveCard"
+                                          Header="{DynamicResource Settings.Game.MouseLock.Reserve.Title}"
+                                          Description="{DynamicResource Settings.Game.MouseLock.Reserve.Desc}"
+                                          Glyph="&#xE8AB;">
+				<ToggleSwitch Name="MouseLockReserveSwitch"
+                              IsCheckedChanged="MouseLockReserveSwitch_OnIsCheckedChanged" />
+			</onePointControls:SettingCard>
+
+			<onePointControls:SettingCard Margin="5, 0"
+                                          Name="MouseLockHotkeyCard"
+                                          Header="{DynamicResource Settings.Game.MouseLock.Hotkey.Title}"
+                                          Description="{DynamicResource Settings.Game.MouseLock.Hotkey.Desc}"
+                                          Glyph="&#xE92E;">
+				<Button Name="MouseLockHotkeyBtn"
+						Height="36"
+						MinWidth="100"
+						Padding="12,0"
+						Content=""
+						Click="MouseLockHotkeyBtn_OnCick"
+                               />
+			</onePointControls:SettingCard>
+
+
+
+		</StackPanel>
+	</ScrollViewer>
+</UserControl>

--- a/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGamePages/MouseLock.axaml.cs
+++ b/src/BedrockBoot/Views/Pages/SettingSubPage/SettingGamePages/MouseLock.axaml.cs
@@ -1,0 +1,142 @@
+﻿using Avalonia.Interactivity;
+using BedrockBoot.Core.Global;
+using BedrockBoot.Interface;
+using BedrockBoot.Models.Helper;
+using BedrockBoot.Views.Pages.MainSubPage;
+using OnePointUI.Avalonia.Base.Entry;
+using OnePointUI.Avalonia.Styling.Controls.OnePointControls.Dialog;
+using System.Collections.Generic;
+
+
+
+namespace BedrockBoot.Views.Pages.SettingSubPage.SettingGamePages;
+
+public partial class MouseLock : ISettingPage
+{
+    public bool IsEdit;
+
+    public MouseLock()
+    {
+        InitializeComponent();
+        BreadcrumbItem = new List<BreadcrumbItemInfo>
+        {
+            new()
+            {
+                ItemName = I18nManager.Instance["Setting.Game.Breadcrumb.Root"],
+                ItemClickAction = s => MainSettingPage.NavigateTo(new SettingGame())
+            },
+            new()
+            {
+                ItemName = I18nManager.Instance["Settings.Game.MouseLock.Title"]
+            }
+        };
+        MouseLockMainSwitch.IsChecked = GlobalModel.Config.Data.IsMouseLock;
+        MouseLockForGdkSwitch.IsChecked = GlobalModel.Config.Data.IsMouseLockForGdk;
+        MouseLockReserveSwitch.IsChecked = GlobalModel.Config.Data.IsMouseLockReserve;
+        MouseLockHotkeyBtn.Content = GlobalModel.Config.Data.MouseLockHotkey;
+        UpdateUI();
+
+        // 理论上讲 Linux 版本应该进不来这个页面吧（
+        IsEdit = true;
+
+    }
+
+    
+
+    private void UpdateUI()
+    {
+        if ((bool)MouseLockMainSwitch.IsChecked!)
+        {
+            MouseLockMainCard.Glyph = "\uF19F";
+            MouseLockForGdkCard.IsEnabled = true;
+            MouseLockReserveCard.IsEnabled = true;
+            MouseLockHotkeyCard.IsEnabled = true;
+        }
+        else
+        {
+            MouseLockMainCard.Glyph = "\uF19E";
+            MouseLockForGdkCard.IsEnabled = false;
+            MouseLockReserveCard.IsEnabled = false;
+            MouseLockHotkeyCard.IsEnabled = false;
+        }
+    }
+
+    private void MouseLockMainSwitch_OnIsCheckedChanged(object? sender, RoutedEventArgs e)
+    {
+        UpdateUI();
+        if (IsEdit)
+        {
+            GlobalModel.Config.Data.IsMouseLock = (bool)MouseLockMainSwitch.IsChecked!;
+            GlobalModel.Config.Save();
+        }
+    }
+    private void MouseLockForGdkSwitch_OnIsCheckedChanged(object? sender, RoutedEventArgs e)
+    {
+        if (IsEdit)
+        {
+            GlobalModel.Config.Data.IsMouseLockForGdk = (bool)MouseLockForGdkSwitch.IsChecked!;
+            GlobalModel.Config.Save();
+        }
+    }
+    private void MouseLockReserveSwitch_OnIsCheckedChanged(object? sender, RoutedEventArgs e)
+    {
+        if (IsEdit)
+        {
+            if((bool)MouseLockReserveSwitch.IsChecked!)
+            {
+                DialogHost.Show(new DialogInfo
+                {
+                    Title = I18nManager.Instance["MainWindow.Dialog.Warning.Title"],
+                    Content = I18nManager.Instance["Settings.Game.MouseLock.Reserve.Warn"],
+                    PrimaryButtonText = I18nManager.Instance["Shared.Action.Confirm"],
+                    CloseButtonText = I18nManager.Instance["Shared.Action.Cancel"],
+                    CloseAction = () =>
+                    {
+                        MouseLockReserveSwitch.IsChecked = false;
+                    },
+                    PrimaryAction = () =>
+                    {
+                        GlobalModel.Config.Data.IsMouseLockReserve = true;
+                        GlobalModel.Config.Save();
+                    }
+                });
+            }
+            else
+            {
+                GlobalModel.Config.Data.IsMouseLockReserve = false;
+                GlobalModel.Config.Save();
+            }
+
+            
+            
+        }
+    }
+   
+    private async void MouseLockHotkeyBtn_OnCick(object? sender, RoutedEventArgs e)
+    {
+#if WINDOWS
+        if (IsEdit)
+        {
+            var oldContent = MouseLockHotkeyBtn.Content;
+
+            MouseLockHotkeyBtn.Content = I18nManager.Instance["Settings.Game.MouseLock.Hotkey.Capturing"];
+
+            var session = HotKeyHelper.Begin(MouseLockHotkeyBtn);
+
+            var hotkey = await session.Task;
+
+            if (hotkey == null)
+            {
+                MouseLockHotkeyBtn.Content = oldContent;
+                return;
+            }
+
+            MouseLockHotkeyBtn.Content = hotkey.ToString();
+
+            GlobalModel.Config.Data.MouseLockHotkey = hotkey.ToString();
+            GlobalModel.Config.Save();
+        }
+#endif
+
+    }
+}


### PR DESCRIPTION
已知目前的鼠标锁有下列问题：
显性问题：
热键没办法正常工作，无论是轻按（完全无法工作）还是按住（勉强能用但是会持续被鼠标锁抢夺回去）
在鼠标锁工作期间，会导致其他鼠标锁定正常的游戏的鼠标锁定异常

隐性问题：
鼠标锁在游戏结束后不退出，线程保留在后台
只需执行一次的 ClipCursor() 却持续多次执行。其持续执行也是致其他鼠标锁定正常的游戏锁定异常的原因
GDK 版本其实是默认不需要鼠标锁的

额不知道写什么了，反正都写在注释上了 ~~（倒~~

btw 文档里面那个鼠标锁还没写可以改改了（


至于 Debug 的情况下光标消失的问题暂时没研究出来，反正 publish 出来的没问题就行
低概率触发无法正确在焦点回到游戏时执行裁切的问题暂时没有稳定复现出来，也没研究